### PR TITLE
Fix wew enter/leave events (ee->detail behavior)

### DIFF
--- a/wew.c
+++ b/wew.c
@@ -99,7 +99,7 @@ motherfuckingenterevent(xcb_generic_event_t *e)
 	xcb_enter_notify_event_t *ee;
 
 	ee = (xcb_enter_notify_event_t*)e;
-	if (ee->detail == 0 && 
+	if (ee->detail != XCB_NOTIFY_DETAIL_INFERIOR &&
 			(ee->mode == XCB_NOTIFY_MODE_NORMAL ||
 			 ee->mode == XCB_NOTIFY_MODE_UNGRAB))
 		return 1;


### PR DESCRIPTION
This fixes the incorrect behavior of wew when dealing with enter and leave events as discussed in #3.

Test case (copied from #3):

Here's an image illustrating the issue: ![](http://i.imgur.com/iLSOGlY.png)

I moved my mouse cursor along the white line. On the left, you can see the output of a modified wew (modified to print out the response_type, detail, and event (contains wid of the window) properties instead of only response_type and wid).

As you can see, the only times that current master would have detected an enter/leave event are the start, the point where it changes directions and goes back, and the end. All these have in common that these are transitions to and from the root window, which is what detail == 0 means.

Event description (in order):

`response_type: ENTER (7) detail: 0 wid: 0x00a00009` Enter border of the first window (from root)
`response_type: LEAVE (8) detail: 2 wid: 0x00a00009` Leave border of the first window (to content)
`response_type: ENTER (7) detail: 2 wid: 0x00a00009` Enter border of the first window (from content)
`response_type: LEAVE (8) detail: 3 wid: 0x00a00009` Leave border of the first window (to content of the second window)
`response_type: ENTER (7) detail: 4 wid: 0x00800009` Enter content of the second window (from border of the first window)
`response_type: ENTER (7) detail: 2 wid: 0x00800009` Enter border of the second window (from content)
`response_type: LEAVE (8) detail: 0 wid: 0x00800009` Leave border of the second window (to root)
`response_type: ENTER (7) detail: 0 wid: 0x00800009` Enter border of the second window (from root)
`response_type: LEAVE (8) detail: 2 wid: 0x00800009` Leave border of the second window (to content)
`response_type: LEAVE (8) detail: 4 wid: 0x00800009` Leave content of the second window (to border of the first window)
`response_type: ENTER (7) detail: 3 wid: 0x00800009` Enter border of the first window (from content of the second window)
`response_type: LEAVE (8) detail: 2 wid: 0x00800009` Leave border of the first window (to content)
`response_type: ENTER (7) detail: 2 wid: 0x00800009` Leave border of the first window (to content)
`response_type: LEAVE (8) detail: 0 wid: 0x00800009` Leave border of the first window (to root)
