### PR TITLE
wew: add click event fixes

### DIFF
--- a/wew.c
+++ b/wew.c
@@ -12,8 +12,8 @@ static xcb_screen_t *scr;
 static uint32_t mask = XCB_EVENT_MASK_NO_EVENT
                      /* | XCB_EVENT_MASK_KEY_PRESS */
                      /* | XCB_EVENT_MASK_KEY_RELEASE */
-                     /* | XCB_EVENT_MASK_BUTTON_PRESS */
-                     /* | XCB_EVENT_MASK_BUTTON_RELEASE */
+                     | XCB_EVENT_MASK_BUTTON_PRESS
+                     | XCB_EVENT_MASK_BUTTON_RELEASE
                      | XCB_EVENT_MASK_ENTER_WINDOW
                      /* | XCB_EVENT_MASK_LEAVE_WINDOW */
                      /* | XCB_EVENT_MASK_POINTER_MOTION */
@@ -137,6 +137,8 @@ get_window_id(xcb_generic_event_t *e)
 
 		case XCB_BUTTON_PRESS:
 		case XCB_BUTTON_RELEASE:
+			xcb_allow_events(conn, XCB_ALLOW_REPLAY_POINTER, XCB_CURRENT_TIME);
+			xcb_flush(conn);
 			wid = ((xcb_button_press_event_t*)e)->child;
 			break;
 
@@ -200,11 +202,12 @@ handle_events(void)
 	register_events(scr->root, XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY);
 
 	if (mask & XCB_EVENT_MASK_BUTTON_PRESS) {
-		xcb_grab_button(conn, 0, scr->root,
-		                XCB_EVENT_MASK_BUTTON_PRESS |
-		                XCB_EVENT_MASK_BUTTON_RELEASE,
-		                XCB_GRAB_MODE_ASYNC, XCB_GRAB_MODE_ASYNC,
-		                scr->root, XCB_NONE, 1, XCB_NONE);
+		xcb_grab_button(conn, 1, scr->root,
+				XCB_EVENT_MASK_BUTTON_PRESS |
+				XCB_EVENT_MASK_BUTTON_RELEASE,
+				XCB_GRAB_MODE_SYNC, XCB_GRAB_MODE_ASYNC,
+				scr->root, XCB_NONE, XCB_BUTTON_INDEX_1, XCB_NONE);
+
 	}
 
 	/* register the events on all mapped windows */


### PR DESCRIPTION
As discussed in #8, this PR introduces fixes to the click event handling.
Currently click events get captured by wew and don't get replayed to the window beneath.

These changes provide a nice and easy way to use click-to-focus instead of the default hover-to-focus behaviour. Theoretically this is faster than a number-crunching script because the X server gives you the ID of the underlying window directly.

A simple way to test this is to put this in your event watcher script:

```
4) if [ "$wid" != "$(pfw)" ]; then
        vroum.sh "$wid" &
    fi
;;
```

I've been running these changes for a few weeks now without any problems.
The only caveat is that event XCB_BUTTON_RELEASE (#5) doesn't get registered with wew at all, so it currently can't be bound. I've spend some time trying to figure out why this is happening, but it's beyond me (though I doubt someone will actually find it useful).

@z3bratabs let me know if you have any remarks.
