### PR TITLE
Add ability to resize windows with the mouse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ SRC =           \
 	wew.c   \
 	chwb2.c \
 	wname.c \
-	xmmv.c
+	xmmv.c  \
+	xmrs.c
 
 OBJ = $(SRC:.c=.o)
 BIN = $(SRC:.c=)

--- a/man/Makefile
+++ b/man/Makefile
@@ -4,7 +4,8 @@ MAN =           \
 	wew.1   \
 	chwb2.1 \
 	wname.1 \
-	xmmv.1
+	xmmv.1  \
+	xmrs.1
 
 .POSIX:
 

--- a/man/xmrs.1
+++ b/man/xmrs.1
@@ -1,0 +1,21 @@
+.Dd July 29, 2016
+.Dt XMRS 1
+.Os wmutils
+.Sh NAME
+.Nm xmrs
+.Nd X mouse resize
+.Sh SYNOPSIS
+.Nm
+.Ar <wid>
+.Sh DESCRIPTION
+.Nm
+resizes windows with mouse, exits on keydown
+.Sh ENVIRONMENT
+.Nm
+acts on the X display specified by the
+.Ev DISPLAY
+variable.
+.Sh SEE ALSO
+.Xr chwb 1,
+.Xr xmmv 1,
+.Xr strtoul 3

--- a/wew.c
+++ b/wew.c
@@ -99,7 +99,7 @@ motherfuckingenterevent(xcb_generic_event_t *e)
 	xcb_enter_notify_event_t *ee;
 
 	ee = (xcb_enter_notify_event_t*)e;
-	if (ee->detail == 0 && 
+	if (ee->detail != XCB_NOTIFY_DETAIL_INFERIOR &&
 			(ee->mode == XCB_NOTIFY_MODE_NORMAL ||
 			 ee->mode == XCB_NOTIFY_MODE_UNGRAB))
 		return 1;

--- a/xmrs.c
+++ b/xmrs.c
@@ -1,0 +1,143 @@
+#include <xcb/xcb.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <err.h>
+
+#include "util.h"
+
+#define CLEANMASK(m)    ((m & ~0x80))
+
+static xcb_connection_t *conn;
+static xcb_screen_t     *scr;
+
+static void usage(char *);
+static xcb_window_t get_focuswin(void);
+static void cleanup(void);
+
+static void
+cleanup(void)
+{
+	kill_xcb(&conn);
+}
+
+static void
+usage(char *name)
+{
+	fprintf(stderr, "usage %s <wid>\n", name);
+	exit(1);
+}
+
+static xcb_window_t
+get_focuswin(void)
+{
+	xcb_window_t w = 0;
+
+	xcb_get_input_focus_cookie_t c;
+	xcb_get_input_focus_reply_t *r;
+
+	c = xcb_get_input_focus(conn);
+	r = xcb_get_input_focus_reply(conn, c, NULL);
+
+	if (r == NULL)
+		errx(1, "failed to get focused window");
+
+	w = r->focus;
+	free(r);
+	return w;
+}
+
+static void
+mresize(xcb_window_t win)
+{
+	uint32_t values[3];
+	xcb_get_geometry_reply_t *geom;
+	xcb_query_pointer_reply_t *ptr;
+	xcb_generic_event_t *ev = NULL;
+	int orig_width, orig_height;
+
+	geom = xcb_get_geometry_reply(conn, xcb_get_geometry(conn, win), NULL);
+	xcb_warp_pointer(conn, XCB_NONE, win, 0, 0, 0, 0,
+					geom->width, geom->height);
+
+	if (!geom)
+		errx(1, "could not get window size.");
+
+	orig_width = geom->width;
+	orig_height = geom->height;
+
+	if (!scr->root)
+		return;
+
+	xcb_grab_pointer(conn, 0, scr->root,
+					XCB_EVENT_MASK_BUTTON_RELEASE
+					| XCB_EVENT_MASK_BUTTON_PRESS,
+					XCB_GRAB_MODE_ASYNC, XCB_GRAB_MODE_ASYNC,
+					scr->root, XCB_NONE, XCB_CURRENT_TIME);
+
+	xcb_flush(conn);
+
+	for (;;) {
+		ev = xcb_poll_for_event(conn);
+
+		if (geom->width != orig_width || geom->height != orig_height) {
+			if (ev != NULL) {
+				if (ev->response_type == XCB_MOTION_NOTIFY)
+					break;
+				exit(0);
+			}
+		}
+
+		geom = xcb_get_geometry_reply(conn,
+						xcb_get_geometry(conn, win), NULL);
+		if (!geom)
+			errx(1, "could not get window size");
+
+		ptr = xcb_query_pointer_reply(conn,
+						xcb_query_pointer(conn, scr->root), 0);
+		if (!ptr)
+			errx(1, "could not get pointer location");
+
+		/* CHANGE */
+		values[0] = abs(ptr->root_x - geom->x);
+		values[1] = abs(ptr->root_y - geom->y);
+/*
+		values[0] = (ptr->root_x + geom->width / 2 > scr->width_in_pixels - (geom->border_width*2))
+				? (scr->width_in_pixels - geom->width - (geom->border_width*2))
+				: ptr->root_x - geom->width / 2;
+		values[1] = (ptr->root_y + geom->height / 2 > scr->width_in_pixels - (geom->border_width*2))
+				? (scr->height_in_pixels - geom->height - (geom->border_width*2))
+				: ptr->root_y - geom->height / 2;
+		if (ptr->root_x < geom->width/2)
+			values[0] = 0;
+		if (ptr->root_y < geom->height/2)
+			values[1] = 0;
+*/
+
+		xcb_configure_window(conn, win, XCB_CONFIG_WINDOW_WIDTH
+						| XCB_CONFIG_WINDOW_HEIGHT, values);
+		xcb_flush(conn);
+	}
+
+	xcb_ungrab_pointer(conn, XCB_CURRENT_TIME);
+}
+
+int
+main(int argc, char **argv)
+{
+	xcb_window_t win;
+	if (argc > 2)
+		usage(argv[0]);
+
+	init_xcb(&conn);
+	get_screen(conn, &scr);
+	atexit(cleanup);
+
+	if (argc == 2)
+		win = strtoul(argv[1], NULL, 16);
+	else
+		win = get_focuswin();
+
+	mresize(win);
+
+	return 0;
+}

--- a/xmrs.c
+++ b/xmrs.c
@@ -100,18 +100,13 @@ mresize(xcb_window_t win)
 		/* CHANGE */
 		values[0] = abs(ptr->root_x - geom->x);
 		values[1] = abs(ptr->root_y - geom->y);
-/*
-		values[0] = (ptr->root_x + geom->width / 2 > scr->width_in_pixels - (geom->border_width*2))
-				? (scr->width_in_pixels - geom->width - (geom->border_width*2))
-				: ptr->root_x - geom->width / 2;
-		values[1] = (ptr->root_y + geom->height / 2 > scr->width_in_pixels - (geom->border_width*2))
-				? (scr->height_in_pixels - geom->height - (geom->border_width*2))
-				: ptr->root_y - geom->height / 2;
-		if (ptr->root_x < geom->width/2)
-			values[0] = 0;
-		if (ptr->root_y < geom->height/2)
-			values[1] = 0;
-*/
+
+		values[0] = (abs(ptr->root_x - geom->x) > scr->width_in_pixels - (geom->border_width*2))
+				? (scr->width_in_pixels - (geom->border_width*2))
+				: abs(ptr->root_x - geom->x);
+		values[1] = (abs(ptr->root_y - geom->y) > scr->height_in_pixels - (geom->border_width*2))
+				? (scr->height_in_pixels - (geom->border_width*2))
+				: abs(ptr->root_y - geom->y);
 
 		xcb_configure_window(conn, win, XCB_CONFIG_WINDOW_WIDTH
 						| XCB_CONFIG_WINDOW_HEIGHT, values);


### PR DESCRIPTION
`xmmv` is great and all, but I also needed a way to resize windows with the mouse. I cannibalized some of 2bwm's resize logic and wmutil's own `xmmv` to create `xmrs`, which resizes windows with the mouse, exiting on keydown.  I hope it's useful.
