### PR TITLE
warp mouse bottom right corner before resizing

### DIFF
--- a/xmrs.c
+++ b/xmrs.c
@@ -57,7 +57,7 @@ mresize(xcb_window_t win) {
 
 	geom = xcb_get_geometry_reply(conn, xcb_get_geometry(conn, win), NULL);
 	xcb_warp_pointer(conn, XCB_NONE, win, 0, 0, 0, 0,
-			geom->width/2, geom->height/2);
+			geom->width, geom->height);
 
 	if (!geom)
 		errx(1, "could not get window size");


### PR DESCRIPTION
Previously when resizing a window, the pointer was moved to the center of the window which made any resize start with a window a quarter of the size of the original.
Now the pointer warps to the bottom right like evilwm, so small window resizes are easy