### PR TITLE
chwb2: Use depth of client

### DIFF
--- a/chwb2.c
+++ b/chwb2.c
@@ -83,7 +83,7 @@ int is; /* inner size  */
 	};
 
 	xcb_pixmap_t pmap = xcb_generate_id(conn);
-	xcb_create_pixmap(conn, scr->root_depth, pmap, win,
+	xcb_create_pixmap(conn, geom->depth, pmap, win,
 			geom->width  + (b*2),
 			geom->height + (b*2));
 	xcb_gcontext_t gc = xcb_generate_id(conn);

--- a/chwb2.c
+++ b/chwb2.c
@@ -25,7 +25,6 @@
 
 char *argv0;
 static xcb_connection_t *conn;
-static xcb_screen_t *scr;
 
 static void usage       (char *name);
 static void set2border  (xcb_window_t, int, int, int, int);
@@ -132,7 +131,6 @@ main (int argc, char **argv)
 	} ARGEND
 
 	init_xcb(&conn);
-	get_screen(conn, &scr);
 
 	/* assume remaining arguments are windows */
 	while (*argv)


### PR DESCRIPTION
When running `chwb2 -I '111111' -O 'cccccc' -i 2 -o 6 "$(pfw)"` in either (possibly other terminal emulators/programs are affected that I haven't tested):
- `termite`
- `alacritty`
- `st (with the alpha patch)` 

It does not apply the border.

It seems to be that the depth of the client needs to be used in order for it to work. This now works as expected.

See https://github.com/tudurom/windowchef/issues/49 for a related issue.