### PR TITLE
correct the order when linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ $(OBJ): $(HDR) util.o
 
 .o:
 	@echo "LD $@"
-	@$(LD) $< -o $@ $(LDFLAGS) util.o
+	@$(LD) $< util.o -o $@ $(LDFLAGS)
 
 .c.o:
 	@echo "CC $<"


### PR DESCRIPTION
I was trying to statically link opt, but ran into an issue.
the instructions in which we run the linker with, in an incorrect order when static linking.
when dynamically linking, this isnt really an issue, but for static linking the order is more important.

in this case, I got missing references for `xcb_connect`, which the linker didnt know it needed, untill it got to `util.o`, at which points itll error out.

putting `$(LDFLAGS)` after `util.o` fixes this.
I made it so it was consistent with how it looks on wmutils/core aswell.
